### PR TITLE
Run the latest stable version of k8s

### DIFF
--- a/bootstrap/minikube.sh
+++ b/bootstrap/minikube.sh
@@ -5,8 +5,8 @@
 #
 
 case "$OSTYPE" in
-  darwin*)  minikube start --driver=hyperkit --kubernetes-version=v1.16.15 ;;
-  linux*)   minikube start --driver=docker --kubernetes-version=v1.16.15 ;;
+  darwin*)  minikube start --driver=hyperkit --kubernetes-version=${K8S_VERSION:-stable} ;;
+  linux*)   minikube start --driver=docker --kubernetes-version=${K8S_VERSION:-stable} ;;
   *)        echo "Uknown/Incompatible OSTYPE: $OSTYPE" ;;
 esac
 


### PR DESCRIPTION
By default run the latest stable version of k8s, but enable the version to be overridden